### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 
-I certify that:
+### Checklist:
 
 * [ ] The readme and documentation has been updated or does not need to be updated
 * [ ] This change has been communicated with the team if needed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,10 @@
-## Description of the change
 
-> Description here
+I certify that:
 
-## Type of change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+* [ ] The readme and documentation has been updated or does not need to be updated
+* [ ] This change has been communicated with the team if needed
+* [ ] I have linked to the original issue
+* [ ] I have added tests to cover my changes
+* [ ] This PR does not need notes or I've added them below
+* [ ] This PR does not need extra testing from our release testing process or I've added a 'tests' section below
 
-## Related issues
-
-> Fix [#1]() 
-
-## Checklists
-
-### Development
-
-- [ ] Lint rules pass locally
-- [ ] The code changed/added as part of this pull request has been covered with tests
-- [ ] All tests related to the changed code pass in development
-
-### Code review 
-
-- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
-- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
-- [ ] Changes have been reviewed by at least one other engineer
-- [ ] Issue from task tracker has a link to this pull request 


### PR DESCRIPTION
I think that the PR template should be something that does not get deleted or modified that must be included in every PR. AND that does not overlap with already enforceable  rules like one reviewer:

part of https://github.com/Plantiga/plantiga.io/issues/3032

I certify that:

* [x] The readme and documentation has been updated or does not need to be updated
* [x] This change has been communicated with the team if needed
* [x] I have linked to the original issue
* [x] I have added tests to cover my changes
* [x] This PR does not need notes or I've added them below
* [x] This PR does not need extra testing from our release testing process or I've added a 'tests' section below
